### PR TITLE
Fix documentation for non-default npm version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ Get available node.js versions::
 Install node.js "0.4.3" without ssl support with 4 parallel commands 
 for compilation and npm.js "0.3.17"::
 
-    $ nodeenv --without-ssl --node=0.4.3 --npm=0.3.17 --jobs=4 env-4.3
+    $ nodeenv --without-ssl --node=0.4.3 --with-npm --npm=0.3.17 --jobs=4 env-4.3
 
 Install node.js from the source::
 


### PR DESCRIPTION
Just updating this as I had to look at the code to figure out why I wasn't getting the right npm version on my environments