### PR TITLE
Add recent example for non-default npm version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,11 @@ for compilation and npm.js "0.3.17"::
 
     $ nodeenv --without-ssl --node=0.4.3 --npm=0.3.17 --jobs=4 env-4.3
 
+Install node.js "10.16.2" and npm.js "6.10.3" (note the with-npm option 
+which is needed for node version above 0.6.3)::
+
+    $ nodeenv --node=10.16.2 --with-npm --npm=6.10.3 output/node env-10.16.2
+
 Install node.js from the source::
 
     $ nodeenv --node=0.10.25 --source env-0.10.25


### PR DESCRIPTION
Just adding this as I had to look at the code to figure out why I wasn't getting the right npm version on my environments